### PR TITLE
FAKECAM: Capture only requests exceptions

### DIFF
--- a/fakecam/fake.py
+++ b/fakecam/fake.py
@@ -55,7 +55,7 @@ def get_frame(cap, background_scaled):
     while mask is None:
         try:
             mask = get_mask(frame)
-        except:
+        except requests.RequestException:
             print("mask request failed, retrying")
     # post-process mask and frame
     mask = post_process_mask(mask)

--- a/fakecam/fake2.py
+++ b/fakecam/fake2.py
@@ -55,7 +55,7 @@ def get_frame(cap, background_scaled):
     while mask is None:
         try:
             mask = get_mask(frame)
-        except:
+        except requests.RequestException:
             print("mask request failed, retrying")
     # post-process mask and frame
     mask = post_process_mask(mask)

--- a/fakecam/fake3.py
+++ b/fakecam/fake3.py
@@ -55,7 +55,7 @@ def get_frame(cap, background_scaled):
     while mask is None:
         try:
             mask = get_mask(frame)
-        except:
+        except requests.RequestException:
             print("mask request failed, retrying")
     # post-process mask and frame
     mask = post_process_mask(mask)


### PR DESCRIPTION
As written, the python script captures all exceptions
and ignores them. This makes things pretty annoying when
we want to use CTRL+C or other system calls to kill the
process as that loop captures those exceptions as well.

This patch addresses the issue by limiting the try/catch
to only catch requests.RequestExceptions.

Signed-off-by: Mark Stenglein <mark@stengle.in>